### PR TITLE
bug/MET-1531: fix tab styling in ie11

### DIFF
--- a/src/assets/sass/pandora/base/_tabs.scss
+++ b/src/assets/sass/pandora/base/_tabs.scss
@@ -13,7 +13,7 @@
 
   li {
     display: inline-block;
-    flex: 1 1 0;
+    flex: 1 1 0px;
 
     a {
       color: $gray-light;

--- a/src/assets/sass/pandora/base/_tabs.scss
+++ b/src/assets/sass/pandora/base/_tabs.scss
@@ -13,7 +13,7 @@
 
   li {
     display: inline-block;
-    flex: 1 1 0px;
+    flex: 1 1 0%;
 
     a {
       color: $gray-light;


### PR DESCRIPTION
flex basis as third argument for flex must have a unit to prevent a bug in ie11, see:

https://github.com/philipwalton/flexbugs#4-flex-shorthand-declarations-with-unitless-flex-basis-values-are-ignored
