### PR TITLE
feat/MET-1543: xml links

### DIFF
--- a/src/app/dataset/mapping/mapping.component.ts
+++ b/src/app/dataset/mapping/mapping.component.ts
@@ -246,4 +246,17 @@ export class MappingComponent implements OnInit {
     this.successMessage = undefined;
   }
 
+  handleCodeClick(event: MouseEvent): void {
+    const target: Element = event.target as Element;
+    if (target && target.classList.contains('cm-string')) {
+      const text = target.textContent || '';
+      const match = /^"(https?:\/\/\S+)"$/.exec(text);
+      if (match) {
+        const url = match[1];
+        if (confirm('Do you want to open the following url in a new window: ' + url + ' ?')) {
+          window.open(url, '_blank');
+        }
+      }
+    }
+  }
 }

--- a/src/app/dataset/mapping/mapping.component.ts
+++ b/src/app/dataset/mapping/mapping.component.ts
@@ -246,17 +246,4 @@ export class MappingComponent implements OnInit {
     this.successMessage = undefined;
   }
 
-  handleCodeClick(event: MouseEvent): void {
-    const target: Element = event.target as Element;
-    if (target && target.classList.contains('cm-string')) {
-      const text = target.textContent || '';
-      const match = /^"(https?:\/\/\S+)"$/.exec(text);
-      if (match) {
-        const url = match[1];
-        if (confirm('Do you want to open the following url in a new window: ' + url + ' ?')) {
-          window.open(url, '_blank');
-        }
-      }
-    }
-  }
 }

--- a/src/app/dataset/preview/preview.component.html
+++ b/src/app/dataset/preview/preview.component.html
@@ -36,7 +36,7 @@
       </div>
     </div>
     <div class="view-sample-editor">
-      <div class="view-sample-editor-codemirror">
+      <div class="view-sample-editor-codemirror" (click)="handleCodeClick($event)">
         <codemirror [ngModel]="sample.xmlRecord | beautifyXML" (ngModelChange)="sample.xmlRecord=$event" [config]="editorConfig"></codemirror>
       </div>
       <a class="load-more-btn" (click)="expandSample(i)" *ngIf="expandedSample !== i">expand</a>
@@ -50,10 +50,10 @@
       <h3>{{sample.ecloudId}} <span *ngIf="selectedPlugin">{{selectedPlugin | renameWorkflow}}</span></h3>
     </div>
     <div class="view-sample-editor">
-      <div class="view-sample-editor-codemirror">
+      <div class="view-sample-editor-codemirror" (click)="handleCodeClick($event)">
         <codemirror [ngModel]="sample.xmlRecord | beautifyXML" (ngModelChange)="sample.xmlRecord=$event" [config]="editorConfig"></codemirror>
       </div>
-      <div class="view-sample-editor-codemirror">
+      <div class="view-sample-editor-codemirror" (click)="handleCodeClick($event)">
         <codemirror *ngIf="allTransformedSamples[i] && allTransformedSamples[i].xmlRecord" [ngModel]="allTransformedSamples[i].xmlRecord | beautifyXML" (ngModelChange)="allTransformedSamples[i].xmlRecord=$event" [config]="editorConfig"></codemirror>
       </div>
       <button (click)="gotoMapping();">{{ 'gotomapping' | translate }}</button>
@@ -65,7 +65,7 @@
   <div class="view-sample-title">
     <h3>{{nosample}}</h3>
   </div>
-  <div class="view-sample-editor" *ngIf="nosample">
+  <div class="view-sample-editor" *ngIf="nosample" (click)="handleCodeClick($event)">
     <codemirror [ngModel]="nosample | beautifyXML" (ngModelChange)="nosample" [config]="editorConfig"></codemirror>
   </div>
 </div>

--- a/src/app/dataset/preview/preview.component.ts
+++ b/src/app/dataset/preview/preview.component.ts
@@ -284,4 +284,18 @@ export class PreviewComponent implements OnInit {
     this.filterDate = false;
     this.filterPlugin = false;
   }
+
+  handleCodeClick(event: MouseEvent): void {
+    const target: Element = event.target as Element;
+    if (target && target.classList.contains('cm-string')) {
+      const text = target.textContent || '';
+      const match = /^"(https?:\/\/\S+)"$/.exec(text);
+      if (match) {
+        const url = match[1];
+        if (confirm('Do you want to open the following url in a new window: ' + url + ' ?')) {
+          window.open(url, '_blank');
+        }
+      }
+    }
+  }
 }

--- a/src/app/dataset/preview/preview.component.ts
+++ b/src/app/dataset/preview/preview.component.ts
@@ -285,16 +285,14 @@ export class PreviewComponent implements OnInit {
     this.filterPlugin = false;
   }
 
+  // if the click is on a http(s) link, open the link in a new tab
   handleCodeClick(event: MouseEvent): void {
     const target: Element = event.target as Element;
     if (target && target.classList.contains('cm-string')) {
       const text = target.textContent || '';
       const match = /^"(https?:\/\/\S+)"$/.exec(text);
       if (match) {
-        const url = match[1];
-        if (confirm('Do you want to open the following url in a new window: ' + url + ' ?')) {
-          window.open(url, '_blank');
-        }
+        window.open(match[1], '_blank');
       }
     }
   }


### PR DESCRIPTION
The Raw Xml tab in Metis provides access to sample xml records. Some fields contain URL or URI a data officer may want to click on to check them.

What to do

1- Investigate if the editor CodeMirror can allow the clicking on links.

2-If yes implement the following: links can be clicked in a record from the Raw XML tab and are opened in a new tab (outside of Metis)

Acceptance criteria

A user can click and open links in records from the Raw xml tab.